### PR TITLE
基于Spring-Cloud-Gateway的SSO Client Demo

### DIFF
--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/README.md
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/README.md
@@ -1,0 +1,8 @@
+# 基于 Spring-Cloud-Gateway 的 SSO Client Demo
+
+* 基于 Spring-Cloud-Gateway 2.0.0.M9 (Spring Boot 2.0.0.RELEASE)
+* 在网关层实现鉴权，登录状态有效的请求才会被路由到对应的服务
+* 由于 Spring Boot 版本问题，本Demo的 pom.xml 不直接继承原来的 sample pom
+
+注意事项：
+**在`DispatcherHandler`中，`RequestMappingHandlerMapping`的优先级高于`RoutePredicateHandlerMapping`，因此请求路径与Controller的RequestMapping一致时，`RequestMappingHandlerMapping`优先处理请求**

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/pom.xml
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.0.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.xuxueli</groupId>
+    <artifactId>xxl-sso-token-sample-spring-cloud-gateway</artifactId>
+    <version>1.1.1-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+
+        <slf4j-api.version>1.7.25</slf4j-api.version>
+        <jedis.version>3.0.0</jedis.version>
+
+        <spring-boot.version>2.0.0.RELEASE</spring-boot.version>
+        <spring-cloud.version>Finchley.M9</spring-cloud.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.xuxueli</groupId>
+            <artifactId>xxl-sso-core</artifactId>
+            <version>${version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/XxlSpringGatewayApplication.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/XxlSpringGatewayApplication.java
@@ -1,0 +1,15 @@
+package com.xxl.sso.sample;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Wu Weijie
+ */
+@SpringBootApplication
+public class XxlSpringGatewayApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(XxlSpringGatewayApplication.class, args);
+    }
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/config/XxlGatewaySsoConfig.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/config/XxlGatewaySsoConfig.java
@@ -1,0 +1,33 @@
+package com.xxl.sso.sample.config;
+
+import com.xxl.sso.core.util.JedisUtil;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author xuxueli 2018-11-15
+ */
+@Configuration
+public class XxlGatewaySsoConfig implements DisposableBean, ApplicationContextAware {
+
+    @Value("${xxl.sso.redis.address}")
+    private String xxlSsoRedisAddress;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        // xxl-sso, redis init
+        JedisUtil.init(xxlSsoRedisAddress);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+
+        // xxl-sso, redis close
+        JedisUtil.close();
+    }
+
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/controller/IndexController.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/controller/IndexController.java
@@ -1,0 +1,24 @@
+package com.xxl.sso.sample.controller;
+
+import com.xxl.sso.core.conf.Conf;
+import com.xxl.sso.core.entity.ReturnT;
+import com.xxl.sso.core.user.XxlSsoUser;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Wu Weijie
+ */
+@RestController
+@RequestMapping("/demo")
+public class IndexController {
+
+    @GetMapping("/user")
+    public Mono<ReturnT<XxlSsoUser>> index(ServerWebExchange exchange) {
+        XxlSsoUser xxlUser = exchange.getAttribute(Conf.SSO_USER);
+        return Mono.just(new ReturnT<>(xxlUser));
+    }
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/filter/XxlSsoTokenGatewayFilter.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/filter/XxlSsoTokenGatewayFilter.java
@@ -1,0 +1,117 @@
+package com.xxl.sso.sample.filter;
+
+import com.xxl.sso.core.conf.Conf;
+import com.xxl.sso.core.entity.ReturnT;
+import com.xxl.sso.core.exception.XxlSsoException;
+import com.xxl.sso.core.path.impl.AntPathMatcher;
+import com.xxl.sso.core.user.XxlSsoUser;
+import com.xxl.sso.sample.helper.XxlGatewaySsoTokenLoginHelper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+
+import static com.xxl.sso.core.conf.Conf.SSO_USER;
+
+/**
+ * @author Wu Weijie
+ */
+@Component
+public class XxlSsoTokenGatewayFilter implements GlobalFilter, Ordered {
+
+    public static final String NOT_LOGIN_MESSAGE = "{\"code\":" + Conf.SSO_LOGIN_FAIL_RESULT.getCode() + ", \"msg\":\"" + Conf.SSO_LOGIN_FAIL_RESULT.getMsg() + "\"}";
+    public static final String ERROR_MESSAGE_TEMPLATE = "'{'\"code\":\"biz.101.100\", \"msg\":\"{0}\"}";
+    public static final String LOGOUT_SUCCESS_MESSAGE = "{\"code\":" + ReturnT.SUCCESS_CODE + ", \"msg\":\"\"}";
+
+    private static final AntPathMatcher ANT_PATH_MATCHER = new AntPathMatcher();
+    @Value("${xxl-sso.excluded.paths}")
+    private String excludedPaths;
+    @Value("${xxl.sso.server}")
+    private String ssoServer;
+    @Value("${xxl.sso.logout.path}")
+    private String logoutPath;
+    @Value("${server.api-prefix}")
+    private String apiPrefix;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        ServerHttpResponse response = exchange.getResponse();
+
+        /*
+        获取请求路径并去掉统一前缀
+        eg:
+        api-prefix=/api
+        requestPath=/api/user/demo
+        处理后：/user/demo
+        统一的前缀可以理解为 server.servlet.context-path
+        但 spring cloud gateway 中暂时没有前缀配置方法，因此自定义一个路径前缀参数
+         */
+        String requestPath = request.getPath().value().substring(apiPrefix.length());
+
+        if (excludedPaths != null && !excludedPaths.trim().isEmpty()) {
+            // if path in excludePaths
+            for (String excludePath : excludedPaths.split(",")) {
+                String uriPattern = excludePath.trim();
+
+                if (ANT_PATH_MATCHER.match(uriPattern, requestPath)) {
+                    // pass
+                    return chain.filter(exchange);
+                }
+            }
+        }
+
+
+        // logout filter
+        if (logoutPath != null
+                && logoutPath.trim().length() > 0
+                && logoutPath.equals(requestPath)) {
+
+            // logout
+            XxlGatewaySsoTokenLoginHelper.logout(request);
+
+            // response
+            response.setStatusCode(HttpStatus.OK);
+            response.getHeaders().add("Content-Type", "application/json;charset=utf-8");
+            return response.writeWith(
+                    Flux.just(response.bufferFactory().wrap(LOGOUT_SUCCESS_MESSAGE.getBytes(StandardCharsets.UTF_8))));
+        }
+
+        // login filter
+        try {
+            XxlSsoUser xxlSsoUser = XxlGatewaySsoTokenLoginHelper.loginCheck(request);
+            if (xxlSsoUser == null) {
+                response.setStatusCode(HttpStatus.OK);
+                response.getHeaders().add("Content-Type", "application/json;charset=utf-8");
+                return response.writeWith(
+                        Flux.just(response.bufferFactory().wrap(NOT_LOGIN_MESSAGE.getBytes(StandardCharsets.UTF_8))));
+            }
+
+            // 用户登录状态有效，滤过
+            exchange.getAttributes().put(SSO_USER, xxlSsoUser);
+            return chain.filter(exchange);
+
+        } catch (XxlSsoException e) {
+            response.setStatusCode(HttpStatus.OK);
+            response.getHeaders().add("Content-Type", "application/json;charset=utf-8");
+            // return error
+            return response.writeWith(
+                    Flux.just(response.bufferFactory().wrap(MessageFormat.format(ERROR_MESSAGE_TEMPLATE, e.getMessage()).getBytes(StandardCharsets.UTF_8))));
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/helper/ReactiveHttpHelper.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/helper/ReactiveHttpHelper.java
@@ -1,0 +1,23 @@
+package com.xxl.sso.sample.helper;
+
+
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+import java.util.Collections;
+
+/**
+ * @author Wu Weijie
+ */
+public class ReactiveHttpHelper {
+
+    /**
+     * 获取请求头
+     *
+     * @param request
+     * @param headerName
+     * @return
+     */
+    public static String getHeader(ServerHttpRequest request, String headerName) {
+        return request.getHeaders().getOrDefault(headerName, Collections.emptyList()).stream().reduce((a, b) -> a + b).orElse(null);
+    }
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/helper/XxlGatewaySsoTokenLoginHelper.java
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/java/com/xxl/sso/sample/helper/XxlGatewaySsoTokenLoginHelper.java
@@ -1,0 +1,32 @@
+package com.xxl.sso.sample.helper;
+
+import com.xxl.sso.core.conf.Conf;
+import com.xxl.sso.core.login.SsoTokenLoginHelper;
+import com.xxl.sso.core.user.XxlSsoUser;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * @author Wu Weijie
+ */
+public class XxlGatewaySsoTokenLoginHelper {
+
+    /**
+     * client login
+     *
+     * @param request
+     * @return
+     */
+    public static XxlSsoUser loginCheck(ServerHttpRequest request) {
+        return SsoTokenLoginHelper.loginCheck(ReactiveHttpHelper.getHeader(request, Conf.SSO_SESSIONID));
+    }
+
+    /**
+     * client logout
+     *
+     * @param request
+     */
+    public static void logout(ServerHttpRequest request) {
+        SsoTokenLoginHelper.logout(ReactiveHttpHelper.getHeader(request, Conf.SSO_SESSIONID));
+    }
+
+}

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/resources/application.properties
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+### web
+server.port=8083
+### xxl-sso
+xxl.sso.server=http://xxlssoserver.com:8080/xxl-sso-server
+xxl.sso.logout.path=/logout
+xxl-sso.excluded.paths=
+xxl.sso.redis.address=redis://127.0.0.1:6379
+server.api-prefix=
+spring.cloud.gateway.routes[0].id=internal
+spring.cloud.gateway.routes[0].uri=forward:/
+spring.cloud.gateway.routes[0].predicates[0]=Path=/internal/user
+spring.cloud.gateway.routes[0].filters[0]=SetPath=/demo/user
+spring.cloud.gateway.routes[1].id=github
+spring.cloud.gateway.routes[1].uri=https://github.com
+spring.cloud.gateway.routes[1].predicates[0]=Path=/xuxueli/**

--- a/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/resources/logback.xml
+++ b/xxl-sso-samples/xxl-sso-token-sample-spring-cloud-gateway/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false" scan="true" scanPeriod="1 seconds">
+
+    <contextName>logback</contextName>
+    <property name="log.path" value="/data/applogs/xxl-sso/xxl-sso-token-sample-springboot.log"/>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- <filter class="ch.qos.logback.classic.filter.ThresholdFilter" >
+             <level>WARN</level>
+         </filter>-->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %contextName [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${log.path}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${log.path}.%d{yyyy-MM-dd}.zip</fileNamePattern>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{36} [%file : %line] %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="console"/>
+        <appender-ref ref="file"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
许老师您好：  

最近我这边基于`Spring-Cloud-Gateway`开发网关层。原有项目的鉴权使用了`xxl-sso`，但`xxl-sso`的过滤器基于`Servlet`实现，无法用于`WebFlux`。我这边抽时间整理了一下基于`Spring-Cloud-Gateway GlobalFilter`实现的过滤逻辑，编写了一个Demo，请您看看。